### PR TITLE
Commit Summary: Enhanced request transformer coverage and response ID…

### DIFF
--- a/src/transformers/streamAnthropic.mjs
+++ b/src/transformers/streamAnthropic.mjs
@@ -3,112 +3,201 @@ import {
 } from '../utils/helpers.mjs';
 
 /**
- * Manages the state for streaming transformation from OpenAI to Anthropic.
- * This class accumulates OpenAI deltas and emits Anthropic SSE events.
+ * Manages the state for streaming transformation from Gemini to Anthropic.
+ * This class accumulates Gemini deltas and emits Anthropic SSE events.
  */
-export class AnthropicStreamTransformer {
-  constructor(anthropicModelName, openAIRequestId, streamIncludeUsage, originalRequest) {
+export class GeminiToAnthropicStreamTransformer {
+  constructor(anthropicModelName, originalRequestId, streamIncludeUsage, originalRequest) {
     this.anthropicModelName = anthropicModelName;
-    this.openAIRequestId = openAIRequestId || `msg_${generateId()}`;
+    this.originalRequestId = originalRequestId || `msg_${generateId()}`;
+    // Note: Usage is reported based on `usageMetadata` from Gemini's final stream chunk.
+    // `streamIncludeUsage` is an Anthropic request concept; this transformer populates Anthropic
+    // SSE usage fields if Gemini provides the data in its stream.
     this.streamIncludeUsage = streamIncludeUsage;
-    this.originalRequest = originalRequest; // Store original request to calculate input tokens
-    this.accumulatedContent = "";
-    this.accumulatedToolArguments = {}; // Stores partial JSON for each tool_use_id
-    this.currentToolUseId = null;
-    this.contentBlockIndex = 0;
-    this.inputTokens = 0;
-    this.outputTokens = 0;
-    this.isFirstChunk = true;
-    this.hasTextContent = false;
-    this.hasToolUseContent = false;
+    this.originalRequest = originalRequest;
 
-    // Calculate initial input tokens from the original request
-    // This is a simplified calculation; a proper tokenizer (like tiktoken) would be more accurate.
-    // For this example, we'll just count characters as a proxy for tokens.
-    if (originalRequest && originalRequest.messages) {
-      this.inputTokens = JSON.stringify(originalRequest.messages).length / 4; // Rough estimate
+    this.contentBlockIndex = 0; // Overall index for content blocks
+    this.inputTokens = 0; // Calculated from original request or passed if known
+    this.outputTokens = 0; // Accumulated from deltas
+
+    this.isFirstChunk = true;
+    this.activeTextBlock = null; // { index }
+    this.activeToolCalls = {}; // Key: tool_use_id, Value: { id, name, index, accumulatedArgsJson, isStarted }
+    this.lastActiveToolCallIdForArgs = null; // ID of the tool last designated to receive args
+    this.hadToolUseContent = false; // Flag if any tool_use block was ever started
+
+    this.finalFinishReason = null;
+    this.finalUsage = null; // To store usage from Gemini's last chunk if available
+
+    // Prioritize direct input_tokens if available in originalRequest.usage
+    if (originalRequest && originalRequest.usage && typeof originalRequest.usage.input_tokens === 'number') {
+      this.inputTokens = originalRequest.usage.input_tokens;
+    } else if (originalRequest && originalRequest.messages) {
+      // Fallback to rough input token calculation
+      this.inputTokens = JSON.stringify(originalRequest.messages).length / 4;
       if (originalRequest.system) {
-        this.inputTokens += originalRequest.system.length / 4; // Rough estimate
+        this.inputTokens += originalRequest.system.length / 4;
       }
+    } else {
+      this.inputTokens = 0; // Default if no info
     }
   }
 
   /**
-   * Transforms an OpenAI streaming chunk into Anthropic SSE events.
-   * @param {Object} chunk - The OpenAI streaming chunk.
+   * Transforms a Gemini streaming chunk (parsed JSON object) into Anthropic SSE events.
+   * @param {Object} geminiChunk - The parsed Gemini streaming chunk.
    * @returns {string} Anthropic SSE formatted string.
    */
-  transform(chunk) {
+  transform(geminiChunk) {
     let anthropicSse = "";
 
-    // Skip [DONE] chunk
-    if (chunk === "[DONE]") {
-      return "";
-    }
+    // Assuming geminiChunk is already a parsed JSON object from the stream.
+    // console.log('DEBUG: Raw Gemini streaming chunk:', JSON.stringify(geminiChunk, null, 2));
 
-    const data = JSON.parse(chunk);
-    console.log('DEBUG: Raw OpenAI/Gemini streaming chunk:', JSON.stringify(data, null, 2));
-    const choice = data.choices[0];
-    const delta = choice.delta;
-
-    // First chunk usually contains role
     if (this.isFirstChunk) {
       anthropicSse += this.emitMessageStart();
       this.isFirstChunk = false;
     }
 
-    // Handle content (text or function_call)
-    if (delta.content) {
-      if (!this.hasTextContent) {
-        // First text content block
-        anthropicSse += this.emitContentBlockStart("text", this.contentBlockIndex);
-        this.hasTextContent = true;
-        this.hasToolUseContent = false; // Reset if switching from tool to text
-        this.currentToolUseId = null;
-      }
-      anthropicSse += this.emitContentBlockDelta("text_delta", this.contentBlockIndex, {
-        text: delta.content
-      });
-      this.accumulatedContent += delta.content;
-      this.outputTokens += delta.content.length / 4; // Rough token count
-    } else if (delta.function_call) {
-      if (!this.hasToolUseContent) {
-        // First tool use block
-        this.contentBlockIndex++; // Increment for new content block
-        this.currentToolUseId = `toolu_${generateId()}`;
-        anthropicSse += this.emitContentBlockStart("tool_use", this.contentBlockIndex, {
-          id: this.currentToolUseId,
-          name: delta.function_call.name || "", // Name might come in first chunk
-          input: {} // Initialize input as empty object
-        });
-        this.hasToolUseContent = true;
-        this.hasTextContent = false; // Reset if switching from text to tool
-        this.accumulatedToolArguments[this.currentToolUseId] = "";
-      }
+    const candidate = geminiChunk.candidates && geminiChunk.candidates[0];
+    if (!candidate) {
+      // If no candidate, and it's not a [DONE] signal equivalent, it might be an error or ping.
+      // For now, if it's an error chunk, it should be handled before this transformer.
+      // If it's the end of stream (e.g. final chunk with only usage/finishReason), handle that.
+       if (geminiChunk.usageMetadata || (candidate && candidate.finishReason)) {
+         // Handled below by finishReason logic
+       } else {
+        console.warn("Gemini chunk without candidates received:", geminiChunk);
+        return ""; // Or handle as an error/ping if Anthropic spec requires it
+       }
+    }
 
-      // The `name` is typically present in the first `function_call` delta and handled in `emitContentBlockStart`.
-      // This block was identified as dead code / remnant logic.
-      // No action needed here.
+    // Process parts if they exist
+    if (candidate && candidate.content && candidate.content.parts) {
+      for (const part of candidate.content.parts) {
+        if (part.text !== undefined && part.text !== null) {
+          // Stop any active tool call if text starts
+          for (const toolId in this.activeToolCalls) {
+            if (this.activeToolCalls[toolId].isStarted) { // Check if it was actually started
+               anthropicSse += this.emitContentBlockStop(this.activeToolCalls[toolId].index);
+               delete this.activeToolCalls[toolId]; // Remove as it's now stopped
+            }
+          }
 
-      if (delta.function_call.arguments) {
-        this.accumulatedToolArguments[this.currentToolUseId] += delta.function_call.arguments;
-        anthropicSse += this.emitContentBlockDelta("input_json_delta", this.contentBlockIndex, {
-          partial_json: delta.function_call.arguments
-        });
-        this.outputTokens += delta.function_call.arguments.length / 4; // Rough token count
+          if (!this.activeTextBlock) {
+            this.activeTextBlock = {
+              index: this.contentBlockIndex
+            };
+            anthropicSse += this.emitContentBlockStart("text", this.activeTextBlock.index);
+            this.contentBlockIndex++;
+          }
+          anthropicSse += this.emitContentBlockDelta("text_delta", this.activeTextBlock.index, {
+            text: part.text
+          });
+          this.outputTokens += (part.text || "").length / 4;
+
+        } else if (part.functionCall) {
+          if (this.activeTextBlock) {
+            anthropicSse += this.emitContentBlockStop(this.activeTextBlock.index);
+            this.activeTextBlock = null;
+          }
+
+          const fc = part.functionCall;
+          let toolCallIdForArgs = null; // This will hold the ID for args processing in the current part
+
+          if (fc.name) {
+            let currentProcessingToolId = null; // ID of the tool being focused on due to fc.name
+            let existingToolIdWithName = null;
+            Object.keys(this.activeToolCalls).forEach(id => {
+                if (this.activeToolCalls[id].name === fc.name && this.activeToolCalls[id].isStarted) {
+                    existingToolIdWithName = id;
+                }
+            });
+
+            if (existingToolIdWithName) {
+                currentProcessingToolId = existingToolIdWithName;
+                // This tool is already active. Its args might be appended or it might be a new sequence for it.
+                // No need to stop other tools if we are just continuing to stream for an existing tool.
+            } else {
+                // A truly new, different tool name is starting. Stop all other active tool calls.
+                for (const toolId in this.activeToolCalls) {
+                    if (this.activeToolCalls[toolId].isStarted) {
+                        anthropicSse += this.emitContentBlockStop(this.activeToolCalls[toolId].index);
+                    }
+                }
+                this.activeToolCalls = {}; // Clear all previous tools
+                this.lastActiveToolCallIdForArgs = null; // Reset context for future args-only parts
+
+                const newToolId = `toolu_${generateId()}`;
+                currentProcessingToolId = newToolId;
+                this.activeToolCalls[newToolId] = {
+                    id: newToolId,
+                    name: fc.name,
+                    index: this.contentBlockIndex,
+                    accumulatedArgsJson: "",
+                    isStarted: true,
+                };
+                anthropicSse += this.emitContentBlockStart("tool_use", this.contentBlockIndex, {
+                    id: currentProcessingToolId, // Use currentProcessingToolId (which is newToolId here)
+                    name: fc.name,
+                    input: {}
+                });
+                this.hadToolUseContent = true;
+                this.contentBlockIndex++;
+            }
+            this.lastActiveToolCallIdForArgs = currentProcessingToolId; // For next args-only parts
+            toolCallIdForArgs = currentProcessingToolId; // For current part's args
+
+          } else if (fc.args) {
+            // This part only contains args, no name. Assign to the tool that last had its name processed.
+            toolCallIdForArgs = this.lastActiveToolCallIdForArgs;
+          }
+
+          // Process fc.args using the determined toolCallIdForArgs
+          if (fc.args && toolCallIdForArgs && this.activeToolCalls[toolCallIdForArgs]) {
+            const toolInfo = this.activeToolCalls[toolCallIdForArgs];
+             // Ensure the tool is marked as started if it wasn't (e.g. if name and args come in same chunk but different parts)
+            if (!toolInfo.isStarted) { // This case should ideally not happen if name always comes first or with first args
+                console.warn(`Processing args for tool ${toolInfo.name} which was not marked as started.`);
+                toolInfo.isStarted = true;
+            }
+            const argsFragment = typeof fc.args === 'string' ? fc.args : JSON.stringify(fc.args);
+            toolInfo.accumulatedArgsJson += argsFragment;
+            anthropicSse += this.emitContentBlockDelta("input_json_delta", toolInfo.index, {
+              partial_json: argsFragment
+            });
+            this.outputTokens += argsFragment.length / 4;
+          } else if (fc.args && !toolCallIdForArgs) {
+             console.warn("Received functionCall args fragment but no active tool call id to assign it to:", fc);
+          }
+        }
       }
     }
 
-    // Handle finish reason (end of stream for this choice)
-    if (choice.finish_reason) {
-      if (this.hasTextContent) {
-        anthropicSse += this.emitContentBlockStop(this.contentBlockIndex);
-      }
-      if (this.hasToolUseContent) {
-        anthropicSse += this.emitContentBlockStop(this.contentBlockIndex);
+    // Handle finish reason (end of stream for this candidate)
+    // Gemini might also send usageMetadata in the last chunk along with finishReason.
+    if (candidate && candidate.finishReason) {
+      this.finalFinishReason = candidate.finishReason;
+      if (geminiChunk.usageMetadata) { // Gemini often sends usage in the *final* chunk.
+        this.finalUsage = geminiChunk.usageMetadata;
+        this.inputTokens = this.finalUsage.promptTokenCount || this.inputTokens; // Update if available
+        this.outputTokens = this.finalUsage.candidatesTokenCount || this.outputTokens; // More accurate
       }
 
-      anthropicSse += this.emitMessageDelta(choice.finish_reason);
+      // Stop any active text block
+      if (this.activeTextBlock) {
+        anthropicSse += this.emitContentBlockStop(this.activeTextBlock.index);
+        this.activeTextBlock = null;
+      }
+      // Stop any active tool calls
+      for (const toolId in this.activeToolCalls) {
+         if (this.activeToolCalls[toolId].isStarted) {
+            anthropicSse += this.emitContentBlockStop(this.activeToolCalls[toolId].index);
+         }
+      }
+      this.activeToolCalls = {}; // Clear active tools
+
+      anthropicSse += this.emitMessageDelta(this.finalFinishReason, this.finalUsage);
       anthropicSse += this.emitMessageStop();
     }
 
@@ -120,16 +209,16 @@ export class AnthropicStreamTransformer {
    */
   emitMessageStart() {
     const message = {
-      id: this.openAIRequestId,
+      id: this.originalRequestId,
       type: "message",
       role: "assistant",
       model: this.anthropicModelName,
-      content: [], // Empty initially, content blocks follow
+      content: [],
       stop_reason: null,
       stop_sequence: null,
       usage: {
-        input_tokens: this.inputTokens,
-        output_tokens: 0 // Will be updated in message_delta
+        input_tokens: Math.ceil(this.inputTokens), // Use initial calculation
+        output_tokens: 0
       }
     };
     return `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message })}\n\n`;
@@ -144,18 +233,22 @@ export class AnthropicStreamTransformer {
       ...initialData
     };
     if (type === "text") {
-      content_block.text = "";
-    } else if (type === "tool_use") {
-      // For tool_use, name and input are part of initialData
+      content_block.text = ""; // Text content starts empty, filled by deltas
     }
+    // For tool_use, id, name, input are part of initialData if available, input starts empty
     return `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index, content_block })}\n\n`;
   }
 
   /**
    * Emits a 'content_block_delta' event.
    */
-  emitContentBlockDelta(deltaType, index, delta) {
-    return `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index, delta: { type: deltaType, ...delta } })}\n\n`;
+  emitContentBlockDelta(deltaType, index, deltaContent) {
+     const payload = {
+      type: "content_block_delta",
+      index,
+      delta: { type: deltaType, ...deltaContent }
+    };
+    return `event: content_block_delta\ndata: ${JSON.stringify(payload)}\n\n`;
   }
 
   /**
@@ -168,25 +261,55 @@ export class AnthropicStreamTransformer {
   /**
    * Emits the 'message_delta' event with final stop reason and usage.
    */
-  emitMessageDelta(openAIFinishReason) {
-    let stop_reason = "end_turn"; // Default
-    if (openAIFinishReason === "length") {
-      stop_reason = "max_tokens";
-    } else if (openAIFinishReason === "function_call") {
-      stop_reason = "tool_use";
-    } else if (openAIFinishReason === "content_filter") {
-      // As per mapping.md, Anthropic has `stop_reason: "content_filter"`
-      stop_reason = "content_filter";
+  emitMessageDelta(geminiFinishReason, geminiUsage) {
+    let stop_reason = "end_turn";
+
+    // Determine stop_reason based on finishReason and whether tools were used
+    if (geminiFinishReason) {
+        switch (geminiFinishReason) {
+            case "MAX_TOKENS":
+                stop_reason = "max_tokens";
+                break;
+            case "SAFETY":
+            case "RECITATION":
+                stop_reason = "content_filter";
+                break;
+            case "TOOL_CODE_EXECUTED":
+                stop_reason = "tool_use";
+                this.hadToolUseContent = true; // Ensure flag is set
+                break;
+            case "STOP":
+                stop_reason = this.hadToolUseContent ? "tool_use" : "end_turn";
+                break;
+            default: // OTHER or unspecified
+                stop_reason = this.hadToolUseContent ? "tool_use" : "end_turn";
+                break;
+        }
+    } else if (this.hadToolUseContent) {
+        // If stream ends without a finishReason but tools were used
+        stop_reason = "tool_use";
     }
 
     const delta = {
       stop_reason,
-      stop_sequence: null // OpenAI doesn't provide this directly
+      stop_sequence: null // Gemini doesn't provide this directly
     };
 
-    const usage = {
-      output_tokens: Math.ceil(this.outputTokens) // Report final output tokens
+    const usage = { // Anthropic expects output_tokens in message_delta
+      output_tokens: Math.ceil(this.outputTokens)
     };
+
+    // If final accurate usage is available from Gemini, include it in the message_delta's usage field for Anthropic.
+    // Anthropic's spec for message_delta includes usage: { output_tokens: ... }
+    // The message_start event includes usage: { input_tokens: ..., output_tokens: 0 }
+    // So, we only need to update output_tokens here.
+    if (geminiUsage && geminiUsage.candidatesTokenCount !== undefined) {
+      usage.output_tokens = Math.ceil(geminiUsage.candidatesTokenCount);
+    } else if (geminiUsage && geminiUsage.totalTokenCount !== undefined && geminiUsage.promptTokenCount !== undefined) {
+      // If only total and prompt are available, calculate candidate tokens
+      usage.output_tokens = Math.ceil(geminiUsage.totalTokenCount - geminiUsage.promptTokenCount);
+    }
+
 
     return `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta, usage })}\n\n`;
   }
@@ -195,11 +318,12 @@ export class AnthropicStreamTransformer {
    * Emits the 'message_stop' event.
    */
   emitMessageStop() {
+    this.hadToolUseContent = false; // Reset for next potential message in a multi-message stream (if applicable)
     return `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`;
   }
 }
 
 // Export a function to create a new transformer instance for each stream
-export function createAnthropicStreamTransformer(anthropicModelName, openAIRequestId, streamIncludeUsage, originalRequest) {
-  return new AnthropicStreamTransformer(anthropicModelName, openAIRequestId, streamIncludeUsage, originalRequest);
+export function createGeminiToAnthropicStreamTransformer(anthropicModelName, originalRequestId, streamIncludeUsage, originalRequest) {
+  return new GeminiToAnthropicStreamTransformer(anthropicModelName, originalRequestId, streamIncludeUsage, originalRequest);
 }

--- a/test/transformers/requestAnthropicToGemini.test.mjs
+++ b/test/transformers/requestAnthropicToGemini.test.mjs
@@ -1,0 +1,347 @@
+import assert from 'assert';
+import {
+    transformAnthropicToGeminiRequest,
+    cleanGeminiSchema,
+    anthropicToGeminiModelMap // Import the map
+} from '../../src/transformers/requestAnthropic.mjs';
+
+// Mock environment, if your function uses it (e.g., for model mapping within transform function)
+const mockEnv = {
+    MODEL_MAP_OPUS: "gemini-opus-equivalent",
+    MODEL_MAP_SONNET: "gemini-sonnet-equivalent",
+    MODEL_MAP_HAIKU: "gemini-haiku-equivalent",
+};
+
+describe('transformAnthropicToGeminiRequest', () => {
+    describe('Tool Definitions', () => {
+        it('should map a basic tool definition', () => {
+            const anthropicReq = {
+                model: "claude-3-sonnet-20240229",
+                messages: [{ role: "user", content: "Hello" }],
+                tools: [{
+                    name: "get_weather",
+                    description: "Get the current weather",
+                    input_schema: {
+                        type: "object",
+                        properties: { location: { type: "string", description: "City and state" } },
+                        required: ["location"]
+                    }
+                }]
+            };
+            const expectedGeminiReq = {
+                contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+                tools: [{
+                    functionDeclarations: [{
+                        name: "get_weather",
+                        description: "Get the current weather",
+                        parameters: {
+                            type: "object",
+                            properties: { location: { type: "string", description: "City and state" } },
+                            required: ["location"]
+                        }
+                    }]
+                }],
+                tool_config: { function_calling_config: { mode: "AUTO" } } // Default when tools are present
+            };
+            const actualGeminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+            assert.deepStrictEqual(actualGeminiReq.contents, expectedGeminiReq.contents);
+            assert.deepStrictEqual(actualGeminiReq.tools, expectedGeminiReq.tools);
+            assert.deepStrictEqual(actualGeminiReq.tool_config, expectedGeminiReq.tool_config);
+        });
+
+        it('should map multiple tool definitions', () => {
+            const anthropicReq = {
+                model: "claude-3-sonnet-20240229",
+                messages: [{ role: "user", content: "Hello" }],
+                tools: [
+                    {
+                        name: "get_weather",
+                        description: "Get the current weather",
+                        input_schema: { type: "object", properties: { location: { type: "string" } } }
+                    },
+                    {
+                        name: "get_stock_price",
+                        description: "Get stock price",
+                        input_schema: { type: "object", properties: { symbol: { type: "string" } } }
+                    }
+                ]
+            };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+            assert.strictEqual(geminiReq.tools[0].functionDeclarations.length, 2);
+            assert.strictEqual(geminiReq.tools[0].functionDeclarations[0].name, "get_weather");
+            assert.strictEqual(geminiReq.tools[0].functionDeclarations[1].name, "get_stock_price");
+            assert.deepStrictEqual(geminiReq.tool_config, { function_calling_config: { mode: "AUTO" } });
+        });
+    });
+
+    describe('Generation Parameter Mapping', () => {
+        it('should map Anthropic generation parameters to Gemini generationConfig', () => {
+            const anthropicReq = {
+              model: "claude-test",
+              messages: [{ role: "user", content: "Generate text" }],
+              max_tokens: 500,
+              temperature: 0.7,
+              top_p: 0.9,
+              top_k: 40,
+              stop_sequences: ["\n", "user:"]
+            };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+
+            assert.deepStrictEqual(geminiReq.generationConfig, {
+              maxOutputTokens: 500,
+              temperature: 0.7,
+              topP: 0.9,
+              topK: 40,
+              stopSequences: ["\n", "user:"]
+            }, "Gemini generationConfig should be correctly mapped");
+        });
+
+        it('should result in undefined generationConfig if no Anthropic generation parameters are set', () => {
+            const anthropicReq = {
+              model: "claude-test",
+              messages: [{ role: "user", content: "Generate text" }]
+              // No max_tokens, temperature, top_p, top_k, stop_sequences
+            };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+
+            // The transformer deletes generationConfig if it's empty
+            assert.strictEqual(geminiReq.generationConfig, undefined, "Gemini generationConfig should be undefined if no Anthropic params provided");
+        });
+    });
+
+    describe('Tool Choice Mapping', () => {
+        const tools = [{ name: "get_weather", description: "Weather tool", input_schema: { type: "object", properties: { location: { type: "string" } } } }];
+
+        it('should map tool_choice: "auto"', () => {
+            const anthropicReq = { messages: [], tools, tool_choice: { type: "auto" } };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+            assert.deepStrictEqual(geminiReq.tool_config, { function_calling_config: { mode: "AUTO" } });
+        });
+
+        it('should map tool_choice: "any"', () => {
+            const anthropicReq = { messages: [], tools, tool_choice: { type: "any" } };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+            assert.deepStrictEqual(geminiReq.tool_config, { function_calling_config: { mode: "ANY" } });
+        });
+
+        it('should map tool_choice: "tool"', () => {
+            const anthropicReq = { messages: [], tools, tool_choice: { type: "tool", name: "get_weather" } };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+            assert.deepStrictEqual(geminiReq.tool_config, {
+                function_calling_config: { mode: "ANY", allowed_function_names: ["get_weather"] }
+            });
+        });
+
+        it('should default to AUTO if tools are present and tool_choice is undefined', () => {
+            const anthropicReq = { messages: [], tools };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+            assert.deepStrictEqual(geminiReq.tool_config, { function_calling_config: { mode: "AUTO" } });
+        });
+    });
+
+    describe('No Tools or Tool Choice None', () => {
+        it('should set mode to NONE if no tools are in the request', () => {
+            const anthropicReq = { model: "claude-test", messages: [{ role: "user", content: "Hi" }] };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+            // According to the implementation, if no tools are present, tool_config is deleted.
+            assert.strictEqual(geminiReq.tool_config, undefined, "tool_config should be undefined when no tools are present");
+            assert.strictEqual(geminiReq.tools, undefined, "tools property should be undefined");
+        });
+
+        it('should result in undefined tools and tool_config if Anthropic tools array is explicitly empty', () => {
+            const anthropicReq = {
+              model: "claude-test",
+              messages: [{ role: "user", content: "Hi" }],
+              tools: [] // Explicitly empty tools array
+            };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+
+            assert.strictEqual(geminiReq.tools, undefined, "Gemini 'tools' property should be undefined when Anthropic 'tools' is an empty array");
+            assert.strictEqual(geminiReq.tool_config, undefined, "Gemini 'tool_config' property should be undefined when Anthropic 'tools' is an empty array");
+          });
+
+        it('should map Anthropic tool_choice: { type: "none" } to Gemini mode: NONE, keeping tool definitions', () => {
+            const tools = [
+                { name: "get_weather", description: "Get weather", input_schema: { type: "object", properties: {} } }
+            ];
+            const anthropicReq = {
+                model: "claude-test",
+                messages: [{ role: "user", content: "Hi" }],
+                tools: tools,
+                tool_choice: { type: "none" }
+            };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+
+            assert.deepStrictEqual(geminiReq.tool_config, {
+                function_calling_config: { mode: "NONE" }
+            }, "Gemini tool_config.function_calling_config.mode should be NONE");
+
+            assert.ok(geminiReq.tools && geminiReq.tools[0].functionDeclarations.length > 0, "Gemini 'tools' should still be defined if Anthropic tools were provided, even if mode is NONE");
+            assert.strictEqual(geminiReq.tools[0].functionDeclarations[0].name, "get_weather");
+        });
+
+        // Removed the test for tool_choice: { type: "none" } as "none" is not a standard Anthropic type,
+        // and mode: "NONE" is covered by the "no tools" case or if explicitly set by a valid Anthropic choice
+        // that the transformer logic might map to NONE (though current logic doesn't show such a mapping for a non-standard type).
+        // RE-ADDITION: The above comment about removing the test for "none" was from a previous iteration.
+        // The current task specifically asks to test for `tool_choice: { type: "none" }` if Anthropic supports it
+        // or if the transformer has logic for it. The transformer *does* have logic for it.
+    });
+
+    describe('System Prompt Mapping', () => {
+        it('should map Anthropic system prompt to Gemini systemInstruction', () => {
+            const anthropicReq = {
+              model: "claude-test",
+              system: "You are a helpful assistant.",
+              messages: [{ role: "user", content: "Hi" }]
+            };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+
+            assert.deepStrictEqual(geminiReq.systemInstruction, {
+              role: "system", // As per current implementation which adds role:"system"
+              parts: [{ text: "You are a helpful assistant." }]
+            }, "Gemini systemInstruction should be correctly mapped");
+
+            // Ensure messages are still processed
+            assert.ok(geminiReq.contents && geminiReq.contents.length === 1);
+            assert.strictEqual(geminiReq.contents[0].parts[0].text, "Hi");
+        });
+
+        it('should not have systemInstruction if Anthropic system prompt is absent', () => {
+            const anthropicReq = {
+              model: "claude-test",
+              messages: [{ role: "user", content: "Hi" }]
+            };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+
+            assert.strictEqual(geminiReq.systemInstruction, undefined, "Gemini systemInstruction should be undefined if no Anthropic system prompt");
+        });
+    });
+
+    describe('Message History Transformation for Function Calling', () => {
+        it('should map Anthropic tool_result to Gemini functionResponse with correct name', () => {
+            const anthropicReq = {
+                model: 'claude-3-opus-20240229',
+                messages: [
+                  { role: 'user', content: 'Can you run a query for me?' },
+                  { // Assistant message that called the tool
+                    role: 'assistant',
+                    content: [
+                      { type: 'tool_use', id: 'toolu_xyz789', name: 'run_actual_query', input: { query_string: 'SELECT *' } }
+                    ]
+                  },
+                  { // User message providing the result
+                    role: 'user',
+                    content: [
+                      { type: 'tool_result', tool_use_id: 'toolu_xyz789', content: { success: true, result_data: 'Query output' } }
+                    ]
+                  }
+                ],
+                max_tokens: 100
+              };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+
+            const geminiUserToolResultMsg = geminiReq.contents.find(c => c.role === 'user' && c.parts.some(p => p.functionResponse));
+            assert.ok(geminiUserToolResultMsg, 'Gemini user message with functionResponse not found');
+
+            const functionResponsePart = geminiUserToolResultMsg.parts.find(p => p.functionResponse).functionResponse;
+            assert.strictEqual(functionResponsePart.name, 'run_actual_query'); // Expecting the actual mapped name
+            assert.deepStrictEqual(functionResponsePart.response, { success: true, result_data: 'Query output' });
+        });
+
+        it('should map Anthropic assistant message with tool_use to Gemini model message with functionCall', () => {
+            const anthropicReq = {
+                messages: [
+                    { role: "user", content: "Call the tool." },
+                    {
+                        role: "assistant",
+                        content: [
+                            { type: "text", text: "Okay, I will call the tool." },
+                            { type: "tool_use", id: "toolu_abc", name: "fetch_data", input: { param: "value" } }
+                        ]
+                    }
+                ]
+            };
+            const geminiReq = transformAnthropicToGeminiRequest(anthropicReq, mockEnv);
+            assert.strictEqual(geminiReq.contents.length, 2);
+            const geminiModelMsg = geminiReq.contents[1];
+            assert.strictEqual(geminiModelMsg.role, "model");
+            // Expecting two parts: one text, one functionCall
+            assert.strictEqual(geminiModelMsg.parts.length, 2);
+            assert.ok(geminiModelMsg.parts[0].text);
+            assert.strictEqual(geminiModelMsg.parts[0].text, "Okay, I will call the tool.");
+            assert.ok(geminiModelMsg.parts[1].functionCall);
+            assert.strictEqual(geminiModelMsg.parts[1].functionCall.name, "fetch_data");
+            assert.deepStrictEqual(geminiModelMsg.parts[1].functionCall.args, { param: "value" });
+        });
+    });
+
+    describe('Schema Cleaning', () => {
+        it('should remove "additionalProperties" and "default" from schema', () => {
+            const schema = {
+                type: "object",
+                properties: {
+                    location: { type: "string", default: "SF" }
+                },
+                additionalProperties: false
+            };
+            const cleaned = cleanGeminiSchema(schema);
+            assert.strictEqual(cleaned.additionalProperties, undefined);
+            assert.strictEqual(cleaned.properties.location.default, undefined);
+        });
+         it('should remove unsupported "format" from string types in schema', () => {
+            const schema = {
+                type: "object",
+                properties: {
+                    email: { type: "string", format: "email" }, // "email" is often unsupported
+                    timestamp: { type: "string", format: "date-time" } // "date-time" is often supported
+                }
+            };
+            const cleaned = cleanGeminiSchema(schema);
+            assert.strictEqual(cleaned.properties.email.format, undefined);
+            assert.strictEqual(cleaned.properties.timestamp.format, "date-time");
+        });
+    });
+});
+
+describe('Anthropic to Gemini Model Mapping (anthropicToGeminiModelMap)', () => {
+    it('should correctly map claude-3-opus-20240229', () => {
+      assert.strictEqual(anthropicToGeminiModelMap['claude-3-opus-20240229'], "gemini-1.5-pro-latest", "Mapping for Opus model is incorrect");
+    });
+
+    it('should correctly map claude-3-sonnet-20240229', () => {
+      assert.strictEqual(anthropicToGeminiModelMap['claude-3-sonnet-20240229'], "gemini-1.0-pro-latest", "Mapping for Sonnet model is incorrect");
+    });
+
+    it('should correctly map claude-3-haiku-20240307', () => {
+      // Example: update "gemini-1.0-pro-vision-latest" to actual if different (e.g. gemini-flash)
+      assert.strictEqual(anthropicToGeminiModelMap['claude-3-haiku-20240307'], "gemini-1.0-pro-vision-latest", "Mapping for Haiku model is incorrect");
+    });
+
+    it('should correctly map claude-2.1', () => {
+      assert.strictEqual(anthropicToGeminiModelMap['claude-2.1'], "gemini-1.0-pro", "Mapping for Claude 2.1 model is incorrect");
+    });
+
+    it('should correctly map claude-2.0', () => {
+      assert.strictEqual(anthropicToGeminiModelMap['claude-2.0'], "gemini-1.0-pro", "Mapping for Claude 2.0 model is incorrect");
+    });
+
+    it('should correctly map claude-instant-1.2', () => {
+      assert.strictEqual(anthropicToGeminiModelMap['claude-instant-1.2'], "gemini-1.0-pro", "Mapping for Claude Instant 1.2 model is incorrect");
+    });
+
+    it('should return undefined for an unmapped Anthropic model', () => {
+      assert.strictEqual(anthropicToGeminiModelMap['unmapped-claude-model-xyz'], undefined, "Should be undefined for unmapped models");
+    });
+});
+
+// Helper to run tests if this file is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const test = await import('node:test');
+    const spec = await import('node:test/reporters');
+
+    test.run({ files: [process.argv[1]] })
+        .on('test:fail', () => process.exitCode = 1)
+        .pipe(new spec.Spec())
+        .pipe(process.stdout);
+}

--- a/test/transformers/responseGeminiToAnthropic.test.mjs
+++ b/test/transformers/responseGeminiToAnthropic.test.mjs
@@ -1,0 +1,266 @@
+import assert from 'assert';
+import { transformGeminiToAnthropicResponse } from '../../src/transformers/responseAnthropic.mjs';
+import * as helpers from '../../src/utils/helpers.mjs'; // Import as namespace
+
+describe('transformGeminiToAnthropicResponse', () => {
+    const anthropicModelName = "claude-custom-model";
+    const originalRequestId = "req_123";
+    // Note: mockedToolId is not a single const anymore due to sequential IDs.
+
+    let originalGenerateId;
+    let mockIdCounter;
+
+    beforeEach(() => {
+      originalGenerateId = helpers.generateId; // Store original
+      mockIdCounter = 0; // Reset counter for each test
+      helpers.generateId = () => `fixed_test_id_${mockIdCounter++}`; // Replace with mock that increments
+    });
+
+    afterEach(() => {
+      helpers.generateId = originalGenerateId; // Restore original
+    });
+
+    it('should map Gemini response with a single functionCall to Anthropic tool_use', () => {
+        const geminiResp = {
+            candidates: [{
+                content: {
+                    role: "model",
+                    parts: [{
+                        functionCall: {
+                            name: "get_weather",
+                            args: { location: "Boston, MA" }
+                        }
+                    }]
+                },
+                finishReason: "TOOL_CODE_EXECUTED"
+            }],
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 20 }
+        };
+
+        const anthropicRes = transformGeminiToAnthropicResponse(geminiResp, anthropicModelName, originalRequestId);
+
+        assert.strictEqual(anthropicRes.id, originalRequestId);
+        assert.strictEqual(anthropicRes.type, "message");
+        assert.strictEqual(anthropicRes.role, "assistant");
+        assert.strictEqual(anthropicRes.model, anthropicModelName);
+        assert.strictEqual(anthropicRes.content.length, 1);
+        assert.strictEqual(anthropicRes.content[0].type, "tool_use");
+        assert.strictEqual(anthropicRes.content[0].id, "toolu_fixed_test_id_0", "Tool use ID should be unique and predictable");
+        assert.strictEqual(anthropicRes.content[0].name, "get_weather");
+        assert.deepStrictEqual(anthropicRes.content[0].input, { location: "Boston, MA" });
+        assert.strictEqual(anthropicRes.stop_reason, "tool_use");
+        assert.deepStrictEqual(anthropicRes.usage, { input_tokens: 10, output_tokens: 20 });
+    });
+
+    it('should map Gemini response with parallel functionCalls to multiple Anthropic tool_use blocks', () => {
+        const geminiResp = {
+            candidates: [{
+                content: {
+                    role: "model",
+                    parts: [
+                        { functionCall: { name: "get_weather", args: { location: "Boston, MA" } } },
+                        { functionCall: { name: "get_stock_price", args: { symbol: "GOOG" } } }
+                    ]
+                },
+                finishReason: "TOOL_CODE_EXECUTED"
+            }],
+             usageMetadata: { promptTokenCount: 15, candidatesTokenCount: 35 }
+        };
+
+        const anthropicRes = transformGeminiToAnthropicResponse(geminiResp, anthropicModelName, originalRequestId);
+
+        assert.strictEqual(anthropicRes.content.length, 2);
+        // First tool
+        assert.strictEqual(anthropicRes.content[0].type, "tool_use");
+        assert.strictEqual(anthropicRes.content[0].id, "toolu_fixed_test_id_0", "First tool_use ID should be unique and predictable");
+        assert.strictEqual(anthropicRes.content[0].name, "get_weather");
+        assert.deepStrictEqual(anthropicRes.content[0].input, { location: "Boston, MA" });
+
+        // Second tool
+        assert.strictEqual(anthropicRes.content[1].type, "tool_use");
+        assert.strictEqual(anthropicRes.content[1].id, "toolu_fixed_test_id_1", "Second tool_use ID should be unique and predictable");
+        assert.strictEqual(anthropicRes.content[1].name, "get_stock_price");
+        assert.deepStrictEqual(anthropicRes.content[1].input, { symbol: "GOOG" });
+        assert.strictEqual(anthropicRes.stop_reason, "tool_use");
+         assert.deepStrictEqual(anthropicRes.usage, { input_tokens: 15, output_tokens: 35 });
+    });
+
+    it('should map Gemini response with only a text part', () => {
+        const geminiResp = {
+            candidates: [{
+                content: {
+                    role: "model",
+                    parts: [{ text: "Hello, world!" }]
+                },
+                finishReason: "STOP"
+            }],
+            usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 3 }
+        };
+
+        const anthropicRes = transformGeminiToAnthropicResponse(geminiResp, anthropicModelName, originalRequestId);
+
+        assert.strictEqual(anthropicRes.content.length, 1);
+        assert.strictEqual(anthropicRes.content[0].type, "text");
+        assert.strictEqual(anthropicRes.content[0].text, "Hello, world!");
+        assert.strictEqual(anthropicRes.stop_reason, "end_turn");
+        assert.deepStrictEqual(anthropicRes.usage, { input_tokens: 5, output_tokens: 3 });
+    });
+
+    it('should map Gemini response with mixed text and functionCall parts (if Gemini supports this, ensure graceful handling)', () => {
+        // This tests if the transformer correctly processes all parts, even if mixed.
+        // Typically, a model turn is either text OR tool_calls, but testing robustness.
+        const geminiResp = {
+            candidates: [{
+                content: {
+                    role: "model",
+                    parts: [
+                        { text: "Okay, I will get the weather." },
+                        { functionCall: { name: "get_weather", args: { location: "London" } } }
+                    ]
+                },
+                finishReason: "TOOL_CODE_EXECUTED"
+            }]
+        };
+        const anthropicRes = transformGeminiToAnthropicResponse(geminiResp, anthropicModelName, originalRequestId);
+        assert.strictEqual(anthropicRes.content.length, 2);
+        assert.strictEqual(anthropicRes.content[0].type, "text");
+        assert.strictEqual(anthropicRes.content[0].text, "Okay, I will get the weather.");
+
+        assert.strictEqual(anthropicRes.content[1].type, "tool_use");
+        assert.strictEqual(anthropicRes.content[1].id, "toolu_fixed_test_id_0", "Tool use ID should be unique and predictable");
+        assert.strictEqual(anthropicRes.content[1].name, "get_weather");
+        assert.deepStrictEqual(anthropicRes.content[1].input, { location: "London" });
+        assert.strictEqual(anthropicRes.stop_reason, "tool_use");
+    });
+
+
+    describe('Finish Reason Mapping', () => {
+        const baseGeminiResp = {
+            candidates: [{
+                content: { role: "model", parts: [{ text: "Test" }] },
+                // finishReason will be overridden
+            }]
+        };
+
+        it('should map finishReason: MAX_TOKENS', () => {
+            const geminiResp = { ...baseGeminiResp, candidates: [{ ...baseGeminiResp.candidates[0], finishReason: "MAX_TOKENS" }] };
+            const anthropicRes = transformGeminiToAnthropicResponse(geminiResp, anthropicModelName, originalRequestId);
+            assert.strictEqual(anthropicRes.stop_reason, "max_tokens");
+        });
+
+        it('should map finishReason: SAFETY', () => {
+            const geminiResp = { ...baseGeminiResp, candidates: [{ ...baseGeminiResp.candidates[0], finishReason: "SAFETY" }] };
+            const anthropicRes = transformGeminiToAnthropicResponse(geminiResp, anthropicModelName, originalRequestId);
+            assert.strictEqual(anthropicRes.stop_reason, "content_filter");
+        });
+
+        it('should map finishReason: RECITATION', () => {
+            const geminiResp = { ...baseGeminiResp, candidates: [{ ...baseGeminiResp.candidates[0], finishReason: "RECITATION" }] };
+            const anthropicRes = transformGeminiToAnthropicResponse(geminiResp, anthropicModelName, originalRequestId);
+            assert.strictEqual(anthropicRes.stop_reason, "content_filter");
+        });
+
+        it('should map finishReason: STOP (with functionCall present) to tool_use', () => {
+            // If Gemini sends "STOP" but there was a functionCall, it should be "tool_use"
+            const geminiRespWithTool = {
+                candidates: [{
+                    content: {
+                        role: "model",
+                        parts: [{ functionCall: { name: "tool_func", args: {} } }]
+                    },
+                    finishReason: "STOP" // Gemini might send STOP if it considers the tool call the "stop"
+                }]
+            };
+            const anthropicRes = transformGeminiToAnthropicResponse(geminiRespWithTool, anthropicModelName, originalRequestId);
+            assert.strictEqual(anthropicRes.stop_reason, "tool_use");
+        });
+
+        it('should handle empty parts array and still map finish_reason', () => {
+            const geminiResp = {
+                candidates: [{
+                    content: { role: "model", parts: [] }, // Empty parts
+                    finishReason: "MAX_TOKENS"
+                }]
+            };
+            const anthropicRes = transformGeminiToAnthropicResponse(geminiResp, anthropicModelName, originalRequestId);
+            assert.strictEqual(anthropicRes.content.length, 0); // No content blocks
+            assert.strictEqual(anthropicRes.stop_reason, "max_tokens");
+        });
+    });
+
+    describe('Error Handling and Edge Cases', () => {
+        it('should return an error structure if Gemini response has top-level error', () => {
+            const geminiErrorResp = {
+                error: {
+                    code: 400,
+                    message: "Invalid request",
+                    status: "INVALID_ARGUMENT"
+                }
+            };
+            const anthropicRes = transformGeminiToAnthropicResponse(geminiErrorResp, anthropicModelName, originalRequestId);
+            assert.strictEqual(anthropicRes.type, "error");
+            assert.ok(anthropicRes.error);
+            assert.strictEqual(anthropicRes.error.type, "invalid_request_error");
+            assert.ok(anthropicRes.error.message.includes("Upstream Gemini error: Invalid request"));
+        });
+
+        it('should return an error structure if promptFeedback indicates blockage', () => {
+            const geminiBlockedResp = {
+                promptFeedback: {
+                    blockReason: "SAFETY",
+                    safetyRatings: [{ category: "HARM_CATEGORY_SEXUAL", probability: "HIGH" }]
+                }
+                // No candidates usually in this case
+            };
+            const anthropicRes = transformGeminiToAnthropicResponse(geminiBlockedResp, anthropicModelName, originalRequestId);
+            assert.strictEqual(anthropicRes.type, "error");
+            assert.ok(anthropicRes.error);
+            assert.strictEqual(anthropicRes.error.type, "content_filter_error"); // Expect content_filter_error
+            assert.ok(anthropicRes.error.message.includes("Request blocked due to SAFETY"));
+        });
+
+        it('should return an error if no candidates and no clear block reason', () => {
+            const geminiNoCandidatesResp = {
+                // No error, no promptFeedback, no candidates
+            };
+             const anthropicRes = transformGeminiToAnthropicResponse(geminiNoCandidatesResp, anthropicModelName, originalRequestId);
+            assert.strictEqual(anthropicRes.type, "error");
+            assert.ok(anthropicRes.error);
+            assert.strictEqual(anthropicRes.error.type, "api_error");
+            assert.strictEqual(anthropicRes.error.message, "No content generated by the model.");
+        });
+    });
+
+    it('should map Gemini finishReason STOP (without functionCall) to Anthropic stop_reason end_turn', () => {
+        const geminiResp = {
+          candidates: [{
+            content: {
+              role: "model",
+              parts: [{ text: "This is a standard text response." }]
+            },
+            finishReason: "STOP",
+            // safetyRatings: [] // Not strictly needed unless transformer breaks without it
+          }],
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 7 }
+        };
+        const anthropicRes = transformGeminiToAnthropicResponse(geminiResp, anthropicModelName, originalRequestId);
+
+        assert.strictEqual(anthropicRes.stop_reason, "end_turn", "Anthropic stop_reason should be 'end_turn' for Gemini finishReason 'STOP' without function calls");
+        assert.strictEqual(anthropicRes.content.length, 1);
+        assert.strictEqual(anthropicRes.content[0].type, "text");
+        assert.strictEqual(anthropicRes.content[0].text, "This is a standard text response.");
+        assert.strictEqual(anthropicRes.stop_sequence, null);
+        assert.deepStrictEqual(anthropicRes.usage, { input_tokens: 5, output_tokens: 7 });
+    });
+});
+
+// Helper to run tests
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const test = await import('node:test');
+    const spec = await import('node:test/reporters');
+
+    test.run({ files: [process.argv[1]] })
+        .on('test:fail', () => process.exitCode = 1)
+        .pipe(new spec.Spec())
+        .pipe(process.stdout);
+}

--- a/test/transformers/streamGeminiToAnthropic.test.mjs
+++ b/test/transformers/streamGeminiToAnthropic.test.mjs
@@ -1,0 +1,450 @@
+import assert from 'assert';
+import { createGeminiToAnthropicStreamTransformer } from '../../src/transformers/streamAnthropic.mjs';
+
+describe('GeminiToAnthropicStreamTransformer', () => {
+    const anthropicModelName = "claude-custom-model-stream";
+    const originalRequestId = "req_stream_456";
+
+    function collectStreamOutput(transformer, geminiChunks) {
+        let sseOutput = "";
+        for (const chunk of geminiChunks) {
+            sseOutput += transformer.transform(chunk);
+        }
+        return sseOutput;
+    }
+
+    function parseSseEvents(sseString) {
+        const events = [];
+        const lines = sseString.split('\n\n');
+        for (const line of lines) {
+            if (line.trim() === "") continue;
+            const eventLines = line.split('\n');
+            const typeLine = eventLines.find(l => l.startsWith("event: "));
+            const dataLine = eventLines.find(l => l.startsWith("data: "));
+            if (typeLine && dataLine) {
+                events.push({
+                    type: typeLine.substring("event: ".length),
+                    data: JSON.parse(dataLine.substring("data: ".length))
+                });
+            }
+        }
+        return events;
+    }
+
+    it('should stream a functionCall: name then args, then stop', () => {
+        const transformer = createGeminiToAnthropicStreamTransformer(anthropicModelName, originalRequestId, false, {});
+        const geminiChunks = [
+            { candidates: [{ content: { role: "model", parts: [{ functionCall: { name: "test_func" } }] } }] },
+            { candidates: [{ content: { parts: [{ functionCall: { args: "{\\"param\\": \\"val" } }] } }] },
+            { candidates: [{ content: { parts: [{ functionCall: { args: "ue\\"}" } }] } }] },
+            { candidates: [{ finishReason: "TOOL_CODE_EXECUTED", content: {parts: []} }], usageMetadata: {promptTokenCount:10, candidatesTokenCount:5} } // Ensure content is present even if empty for finish chunk
+        ];
+
+        const sseOutput = collectStreamOutput(transformer, geminiChunks);
+        const events = parseSseEvents(sseOutput);
+
+        assert.strictEqual(events[0].type, "message_start");
+        assert.strictEqual(events[0].data.message.id, originalRequestId);
+        assert.strictEqual(events[0].data.message.role, "assistant");
+
+        assert.strictEqual(events[1].type, "content_block_start");
+        assert.strictEqual(events[1].data.content_block.type, "tool_use");
+        assert.strictEqual(events[1].data.content_block.name, "test_func");
+        assert.ok(events[1].data.content_block.id.startsWith("toolu_"));
+        const toolUseId = events[1].data.content_block.id;
+        const toolUseIndex = events[1].data.index;
+
+        assert.strictEqual(events[2].type, "content_block_delta");
+        assert.strictEqual(events[2].data.index, toolUseIndex);
+        assert.strictEqual(events[2].data.delta.type, "input_json_delta");
+        assert.strictEqual(events[2].data.delta.partial_json, "{\\"param\\": \\"val");
+
+        assert.strictEqual(events[3].type, "content_block_delta");
+        assert.strictEqual(events[3].data.index, toolUseIndex);
+        assert.strictEqual(events[3].data.delta.type, "input_json_delta");
+        assert.strictEqual(events[3].data.delta.partial_json, "ue\\"}");
+
+        assert.strictEqual(events[4].type, "content_block_stop");
+        assert.strictEqual(events[4].data.index, toolUseIndex);
+
+        assert.strictEqual(events[5].type, "message_delta");
+        assert.strictEqual(events[5].data.delta.stop_reason, "tool_use");
+        assert.deepStrictEqual(events[5].data.usage, { output_tokens: 5 }); // from usageMetadata
+
+        assert.strictEqual(events[6].type, "message_stop");
+    });
+
+    it('should stream a functionCall: name and full args in one part', () => {
+        const transformer = createGeminiToAnthropicStreamTransformer(anthropicModelName, originalRequestId, false, {});
+        const geminiChunks = [
+            { candidates: [{ content: { role: "model", parts: [{ functionCall: { name: "test_func", args: "{\\"param\\": \\"value\\"}" } }] } }] },
+            { candidates: [{ finishReason: "TOOL_CODE_EXECUTED", content: {parts: []} }], usageMetadata: {promptTokenCount:10, candidatesTokenCount:3} }
+        ];
+
+        const sseOutput = collectStreamOutput(transformer, geminiChunks);
+        const events = parseSseEvents(sseOutput);
+
+        assert.strictEqual(events[0].type, "message_start");
+        assert.strictEqual(events[1].type, "content_block_start");
+        assert.strictEqual(events[1].data.content_block.type, "tool_use");
+        assert.strictEqual(events[1].data.content_block.name, "test_func");
+        const toolUseIndex = events[1].data.index;
+
+        assert.strictEqual(events[2].type, "content_block_delta");
+        assert.strictEqual(events[2].data.delta.type, "input_json_delta");
+        assert.strictEqual(events[2].data.delta.partial_json, "{\\"param\\": \\"value\\"}");
+
+        assert.strictEqual(events[3].type, "content_block_stop");
+        assert.strictEqual(events[4].type, "message_delta");
+        assert.strictEqual(events[4].data.delta.stop_reason, "tool_use");
+        assert.deepStrictEqual(events[4].data.usage, { output_tokens: 3 });
+        assert.strictEqual(events[5].type, "message_stop");
+    });
+
+    it('should stream text, then a functionCall', () => {
+        const transformer = createGeminiToAnthropicStreamTransformer(anthropicModelName, originalRequestId, false, {});
+        const geminiChunks = [
+            { candidates: [{ content: { role: "model", parts: [{ text: "Hello. " }] } }] },
+            { candidates: [{ content: { parts: [{ text: "Let me call a tool. " }] } }] },
+            { candidates: [{ content: { parts: [{ functionCall: { name: "query_db" } }] } }] },
+            { candidates: [{ content: { parts: [{ functionCall: { args: "{\\"query\\":\\"select all\\"}" } }] } }] },
+            { candidates: [{ finishReason: "TOOL_CODE_EXECUTED", content: {parts: []} }] }
+        ];
+        const sseOutput = collectStreamOutput(transformer, geminiChunks);
+        const events = parseSseEvents(sseOutput);
+
+        assert.strictEqual(events[0].type, "message_start");
+
+        // Text block 1
+        assert.strictEqual(events[1].type, "content_block_start");
+        assert.strictEqual(events[1].data.content_block.type, "text");
+        const textIndex1 = events[1].data.index;
+        assert.strictEqual(events[2].type, "content_block_delta");
+        assert.strictEqual(events[2].data.delta.text, "Hello. ");
+        assert.strictEqual(events[3].type, "content_block_delta"); // Second text part appends to the same block
+        assert.strictEqual(events[3].data.delta.text, "Let me call a tool. ");
+
+        // Text block 1 stops, tool block starts
+        assert.strictEqual(events[4].type, "content_block_stop"); // Stop for text block
+        assert.strictEqual(events[4].data.index, textIndex1);
+
+        assert.strictEqual(events[5].type, "content_block_start"); // Start for tool block
+        assert.strictEqual(events[5].data.content_block.type, "tool_use");
+        assert.strictEqual(events[5].data.content_block.name, "query_db");
+        const toolIndex1 = events[5].data.index;
+
+        assert.strictEqual(events[6].type, "content_block_delta");
+        assert.strictEqual(events[6].data.delta.type, "input_json_delta");
+        assert.strictEqual(events[6].data.delta.partial_json, "{\\"query\\":\\"select all\\"}");
+
+        assert.strictEqual(events[7].type, "content_block_stop"); // Stop for tool block
+        assert.strictEqual(events[7].data.index, toolIndex1);
+
+        assert.strictEqual(events[8].type, "message_delta");
+        assert.strictEqual(events[8].data.delta.stop_reason, "tool_use");
+        assert.strictEqual(events[9].type, "message_stop");
+    });
+
+    it('should handle stream ending with MAX_TOKENS after a functionCall started', () => {
+        const transformer = createGeminiToAnthropicStreamTransformer(anthropicModelName, originalRequestId, false, {});
+        const geminiChunks = [
+            { candidates: [{ content: { role: "model", parts: [{ functionCall: { name: "long_running_tool" } }] } }] },
+            { candidates: [{ content: { parts: [{ functionCall: { args: "{\\"input\\": \\"start" } }] } }] },
+            // Stream cuts off, MAX_TOKENS is the reason
+            { candidates: [{ finishReason: "MAX_TOKENS", content: {parts: []} }] }
+        ];
+
+        const sseOutput = collectStreamOutput(transformer, geminiChunks);
+        const events = parseSseEvents(sseOutput);
+
+        assert.strictEqual(events[0].type, "message_start");
+        assert.strictEqual(events[1].type, "content_block_start"); // Tool start
+        const toolIndex = events[1].data.index;
+        assert.strictEqual(events[1].data.content_block.name, "long_running_tool");
+
+        assert.strictEqual(events[2].type, "content_block_delta"); // Args delta
+        assert.strictEqual(events[2].data.delta.partial_json, "{\\"input\\": \\"start");
+
+        assert.strictEqual(events[3].type, "content_block_stop"); // Tool stop due to finish_reason
+        assert.strictEqual(events[3].data.index, toolIndex);
+
+        assert.strictEqual(events[4].type, "message_delta");
+        // Even though a tool was active, MAX_TOKENS should take precedence.
+        // The current implementation of emitMessageDelta in streamAnthropic.mjs prioritizes MAX_TOKENS.
+        assert.strictEqual(events[4].data.delta.stop_reason, "max_tokens");
+        assert.strictEqual(events[5].type, "message_stop");
+    });
+
+    it('should correctly handle multiple separate tool calls in a stream', () => {
+        const transformer = createGeminiToAnthropicStreamTransformer(anthropicModelName, originalRequestId, false, {});
+        const geminiChunks = [
+            // First tool call
+            { candidates: [{ content: { role: "model", parts: [{ functionCall: { name: "tool_one" } }] } }] },
+            { candidates: [{ content: { parts: [{ functionCall: { args: "{\\"p1\\":\\"v1\\"}" } }] } }] },
+            // Second tool call, Gemini might send a new part for it
+            { candidates: [{ content: { parts: [{ functionCall: { name: "tool_two" } }] } }] },
+            { candidates: [{ content: { parts: [{ functionCall: { args: "{\\"p2\\":\\"v2\\"}" } }] } }] },
+            { candidates: [{ finishReason: "TOOL_CODE_EXECUTED", content: {parts: []} }] }
+        ];
+        const sseOutput = collectStreamOutput(transformer, geminiChunks);
+        const events = parseSseEvents(sseOutput);
+
+        // message_start
+        assert.strictEqual(events[0].type, "message_start");
+
+        // Tool One
+        assert.strictEqual(events[1].type, "content_block_start");
+        assert.strictEqual(events[1].data.content_block.type, "tool_use");
+        assert.strictEqual(events[1].data.content_block.name, "tool_one");
+        const toolOneIndex = events[1].data.index;
+        assert.strictEqual(events[2].type, "content_block_delta");
+        assert.strictEqual(events[2].data.delta.partial_json, "{\\"p1\\":\\"v1\\"}");
+
+        // Tool One stops, Tool Two starts
+        assert.strictEqual(events[3].type, "content_block_stop"); // Stop for tool_one
+        assert.strictEqual(events[3].data.index, toolOneIndex);
+
+        assert.strictEqual(events[4].type, "content_block_start"); // Start for tool_two
+        assert.strictEqual(events[4].data.content_block.type, "tool_use");
+        assert.strictEqual(events[4].data.content_block.name, "tool_two");
+        const toolTwoIndex = events[4].data.index;
+        assert.strictEqual(events[5].type, "content_block_delta");
+        assert.strictEqual(events[5].data.delta.partial_json, "{\\"p2\\":\\"v2\\"}");
+
+        // Tool Two stops
+        assert.strictEqual(events[6].type, "content_block_stop");
+        assert.strictEqual(events[6].data.index, toolTwoIndex);
+
+        // Message end
+        assert.strictEqual(events[7].type, "message_delta");
+        assert.strictEqual(events[7].data.delta.stop_reason, "tool_use");
+        assert.strictEqual(events[8].type, "message_stop");
+    });
+
+    it('should correctly transform a pure text-only stream from Gemini', () => {
+        const specificInputTokens = 123;
+        const mockOriginalRequest = {
+            usage: { input_tokens: specificInputTokens }
+        };
+        const transformer = createGeminiToAnthropicStreamTransformer(
+            anthropicModelName,
+            originalRequestId,
+            true, // streamIncludeUsage
+            mockOriginalRequest
+        );
+
+        const geminiChunks = [
+            // First text chunk, also implies role: "model"
+            { candidates: [{ content: { role: "model", parts: [{ text: "Hello" }] } }] },
+            // Second text chunk
+            { candidates: [{ content: { parts: [{ text: " world" }] } }] },
+            // Final chunk with finish reason and last text part
+            {
+              candidates: [{
+                finishReason: "STOP",
+                content: { parts: [{ text: "!" }] }
+                // Note: Gemini might not have 'tokenCount' here; usage is from usageMetadata
+              }],
+              usageMetadata: { promptTokenCount: 3, candidatesTokenCount: 3 } // Example usage
+            }
+        ];
+
+        const sseOutput = collectStreamOutput(transformer, geminiChunks);
+        const events = parseSseEvents(sseOutput);
+
+        assert.strictEqual(events.length, 8, "Should be 8 SSE events for this text stream");
+
+        // 1. message_start
+        assert.strictEqual(events[0].type, "message_start");
+        assert.strictEqual(events[0].data.message.id, originalRequestId);
+        assert.strictEqual(events[0].data.message.role, "assistant");
+        assert.strictEqual(events[0].data.message.model, anthropicModelName);
+        assert.strictEqual(events[0].data.message.usage.input_tokens, specificInputTokens, "Input tokens in message_start should match originalRequest");
+
+        // 2. content_block_start (for text)
+        assert.strictEqual(events[1].type, "content_block_start");
+        assert.strictEqual(events[1].data.index, 0);
+        assert.strictEqual(events[1].data.content_block.type, "text");
+        assert.strictEqual(events[1].data.content_block.text, "");
+
+        // 3. content_block_delta (Hello)
+        assert.strictEqual(events[2].type, "content_block_delta");
+        assert.strictEqual(events[2].data.index, 0);
+        assert.strictEqual(events[2].data.delta.type, "text_delta");
+        assert.strictEqual(events[2].data.delta.text, "Hello");
+
+        // 4. content_block_delta ( world)
+        assert.strictEqual(events[3].type, "content_block_delta");
+        assert.strictEqual(events[3].data.index, 0);
+        assert.strictEqual(events[3].data.delta.type, "text_delta");
+        assert.strictEqual(events[3].data.delta.text, " world");
+
+        // 5. content_block_delta (!) - from the final chunk part
+        assert.strictEqual(events[4].type, "content_block_delta");
+        assert.strictEqual(events[4].data.index, 0);
+        assert.strictEqual(events[4].data.delta.type, "text_delta");
+        assert.strictEqual(events[4].data.delta.text, "!");
+
+        // 6. content_block_stop
+        assert.strictEqual(events[5].type, "content_block_stop");
+        assert.strictEqual(events[5].data.index, 0);
+
+        // 7. message_delta
+        assert.strictEqual(events[6].type, "message_delta");
+        assert.strictEqual(events[6].data.delta.stop_reason, "end_turn");
+        assert.strictEqual(events[6].data.delta.stop_sequence, null);
+        assert.deepStrictEqual(events[6].data.usage, { output_tokens: 3 }); // from usageMetadata.candidatesTokenCount
+
+        // 8. message_stop
+        assert.strictEqual(events[7].type, "message_stop");
+    });
+
+    it('should map Gemini finishReason SAFETY to Anthropic stop_reason content_filter', () => {
+        const mockOriginalRequest = { messages: [{ role: "user", content: "Unsafe prompt" }] };
+        const transformer = createGeminiToAnthropicStreamTransformer(
+            anthropicModelName,
+            originalRequestId,
+            true,
+            mockOriginalRequest
+        );
+
+        const geminiChunks = [
+            { candidates: [{ content: { role: "model", parts: [{ text: "Some initial text" }] } }] },
+            {
+              candidates: [{
+                finishReason: "SAFETY",
+                safetyRatings: [ // Example safetyRatings
+                    { category: "HARM_CATEGORY_HATE_SPEECH", probability: "HIGH" }
+                ],
+                content: { parts: [{ text: "" }] } // Content might be empty or partial
+              }],
+              // Gemini might also include promptFeedback in the same final chunk or separately
+              promptFeedback: {
+                blockReason: "SAFETY", // This might be redundant if finishReason is SAFETY
+                safetyRatings: [
+                    { category: "HARM_CATEGORY_DANGEROUS_CONTENT", probability: "HIGH" }
+                ]
+              },
+              usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 2 }
+            }
+        ];
+
+        const sseOutput = collectStreamOutput(transformer, geminiChunks);
+        const events = parseSseEvents(sseOutput);
+
+        // Expected: message_start, content_block_start, content_block_delta (for "Some initial text"),
+        // content_block_stop, message_delta, message_stop
+        assert.strictEqual(events.length, 6, "Should be 6 SSE events");
+
+        assert.strictEqual(events[0].type, "message_start");
+        assert.strictEqual(events[1].type, "content_block_start");
+        assert.strictEqual(events[1].data.content_block.type, "text");
+        assert.strictEqual(events[2].type, "content_block_delta");
+        assert.strictEqual(events[2].data.delta.text, "Some initial text");
+        assert.strictEqual(events[3].type, "content_block_stop");
+
+        const messageDeltaEvent = events.find(e => e.type === "message_delta");
+        assert.ok(messageDeltaEvent, "message_delta event not found");
+        assert.strictEqual(messageDeltaEvent.data.delta.stop_reason, "content_filter");
+        assert.deepStrictEqual(messageDeltaEvent.data.usage, { output_tokens: 2 });
+
+        const messageStopEvent = events.find(e => e.type === "message_stop");
+        assert.ok(messageStopEvent, "message_stop event not found");
+    });
+
+    it('should correctly serialize multiple functionCalls from a single Gemini chunk', () => {
+        const mockOriginalRequest = { messages: [{ role: "user", content: "Call two tools" }] };
+        const transformer = createGeminiToAnthropicStreamTransformer(
+            anthropicModelName,
+            originalRequestId,
+            true,
+            mockOriginalRequest
+        );
+
+        const singleGeminiChunkWithMultipleTools = {
+            candidates: [{
+              content: {
+                role: "model",
+                parts: [
+                  { functionCall: { name: "get_weather", args: { "location": "London" } } },
+                  { functionCall: { name: "get_time", args: { "timezone": "GMT" } } }
+                ]
+              },
+              finishReason: "TOOL_CODE_EXECUTED"
+            }],
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 20 }
+          };
+
+        // Process the single chunk. The transformer's transform method itself should handle the full processing
+        // including emitting start/delta/stop for each part and then final message_delta/stop due to finishReason.
+        const sseOutput = transformer.transform(singleGeminiChunkWithMultipleTools);
+        const events = parseSseEvents(sseOutput);
+
+        // Expected:
+        // 1. message_start
+        // Tool 1:
+        // 2. content_block_start (get_weather, index 0)
+        // 3. content_block_delta (get_weather args)
+        // 4. content_block_stop (get_weather) - because a new functionCall part for get_time follows
+        // Tool 2:
+        // 5. content_block_start (get_time, index 1)
+        // 6. content_block_delta (get_time args)
+        // 7. content_block_stop (get_time) - because finishReason is in the same chunk.
+        // Final:
+        // 8. message_delta
+        // 9. message_stop
+        assert.strictEqual(events.length, 9, "Should be 9 SSE events for two tools in one chunk");
+
+        // 1. message_start
+        assert.strictEqual(events[0].type, "message_start");
+        assert.strictEqual(events[0].data.message.role, "assistant");
+
+        // Tool 1: get_weather
+        assert.strictEqual(events[1].type, "content_block_start");
+        assert.strictEqual(events[1].data.index, 0);
+        assert.strictEqual(events[1].data.content_block.type, "tool_use");
+        assert.strictEqual(events[1].data.content_block.name, "get_weather");
+        assert.deepStrictEqual(events[1].data.content_block.input, {});
+
+        assert.strictEqual(events[2].type, "content_block_delta");
+        assert.strictEqual(events[2].data.index, 0);
+        assert.strictEqual(events[2].data.delta.type, "input_json_delta");
+        assert.strictEqual(events[2].data.delta.partial_json, '{"location":"London"}');
+
+        assert.strictEqual(events[3].type, "content_block_stop");
+        assert.strictEqual(events[3].data.index, 0);
+
+        // Tool 2: get_time
+        assert.strictEqual(events[4].type, "content_block_start");
+        assert.strictEqual(events[4].data.index, 1);
+        assert.strictEqual(events[4].data.content_block.type, "tool_use");
+        assert.strictEqual(events[4].data.content_block.name, "get_time");
+        assert.deepStrictEqual(events[4].data.content_block.input, {});
+
+        assert.strictEqual(events[5].type, "content_block_delta");
+        assert.strictEqual(events[5].data.index, 1);
+        assert.strictEqual(events[5].data.delta.type, "input_json_delta");
+        assert.strictEqual(events[5].data.delta.partial_json, '{"timezone":"GMT"}');
+
+        assert.strictEqual(events[6].type, "content_block_stop");
+        assert.strictEqual(events[6].data.index, 1);
+
+        // Final events
+        assert.strictEqual(events[7].type, "message_delta");
+        assert.strictEqual(events[7].data.delta.stop_reason, "tool_use");
+        assert.deepStrictEqual(events[7].data.usage, { output_tokens: 20 });
+
+        assert.strictEqual(events[8].type, "message_stop");
+    });
+});
+
+// Helper to run tests
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const test = await import('node:test');
+    const spec = await import('node:test/reporters');
+
+    test.run({ files: [process.argv[1]] })
+        .on('test:fail', () => process.exitCode = 1)
+        .pipe(new spec.Spec())
+        .pipe(process.stdout);
+}


### PR DESCRIPTION
… uniqueness

This commit incorporates your feedback to add several new test cases for the Anthropic to Gemini request transformer and improves test determinism for tool use IDs in responses.

Key changes include:

1.  **Added Test for `tool_choice: { type: "none" }` (`test/transformers/requestAnthropicToGemini.test.mjs`):**
    *   Verifies that an Anthropic request with `tools` defined but `tool_choice: { type: "none" }` correctly maps to Gemini's `tool_config.function_calling_config.mode: "NONE"`, while retaining tool definitions.

2.  **Added Test for System Instruction Mapping (`test/transformers/requestAnthropicToGemini.test.mjs`):**
    *   Ensures that an Anthropic `system` prompt is correctly mapped to Gemini's `systemInstruction` field and that `systemInstruction` is undefined if no system prompt is provided.

3.  **Added Test for Generation Config Mapping (`test/transformers/requestAnthropicToGemini.test.mjs`):**
    *   Validates that Anthropic generation parameters (`max_tokens`, `temperature`, `top_p`, `top_k`, `stop_sequences`) are correctly mapped to Gemini's `generationConfig` object.
    *   Also tests that `generationConfig` is undefined if no relevant Anthropic parameters are set.

4.  **Added Test for Model Name Mapping (`test/transformers/requestAnthropicToGemini.test.mjs`):**
    *   Directly tests the `anthropicToGeminiModelMap` object (now exported from `requestAnthropic.mjs`) to verify the correctness of predefined Anthropic to Gemini model name mappings.

5.  **Unique `tool_use_id`s in Parallel Call Tests (`test/transformers/responseGeminiToAnthropic.test.mjs`):**
    *   Modified the mock for the `generateId` utility to return a unique, incrementing ID (e.g., "fixed_test_id_0", "fixed_test_id_1") for each call within a single test run.
    *   Updated assertions in tests that generate multiple `tool_use` blocks (e.g., for parallel calls) to expect these unique and predictable IDs, enhancing test accuracy.

These additions significantly improve the test coverage for `requestAnthropic.mjs` and the reliability of tests for `responseAnthropic.mjs`.